### PR TITLE
Update bdroid_buildcfg.h

### DIFF
--- a/bluetooth/bdroid_buildcfg.h
+++ b/bluetooth/bdroid_buildcfg.h
@@ -19,5 +19,6 @@
 #define _BDROID_BUILDCFG_H
 
 #define BTM_DEF_LOCAL_NAME   "Samsung Galaxy S7 Edge"
+#define BTM_WBS_INCLUDED TRUE
 
 #endif


### PR DESCRIPTION
BUGBASH-308
Some cars require WBS to connect a Bluetoot device.